### PR TITLE
Card grows bigger on hover

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -59,8 +59,10 @@
   border-radius: 16px;
   background-color: #ededed;
   box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.15);
+  transition: 0.2s;
   &:hover {
     box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.18);
+    transform: scale(1.02);
   }
 }
 


### PR DESCRIPTION
attached is how the card grows bigger, still has the old design, we can merge [branch 27](https://github.com/abauville/lickwars/pull/27) before we merge this branch to prevent conflicts. attached is the video that shows this function

https://www.veed.io/view/988953f1-0b97-4644-b15e-0157d1bae6a9