### PR TITLE
Add progress bar to exercises index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem 'devise'
 gem 'autoprefixer-rails', '10.2.5'
 gem 'font-awesome-sass'
 gem 'simple_form'
+# gem for charts
+gem "chartkick"
 group :development, :test do  gem 'pry-byebug'
   gem 'pry-rails'
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chartkick (4.1.3)
     childprocess (4.1.0)
     cloudinary (1.16.1)
       aws_cf_signer
@@ -285,6 +286,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
+  chartkick
   cloudinary (~> 1.16.0)
   devise
   dotenv-rails

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -2,3 +2,4 @@
 @import "home";
 @import "teacher/exercises/index";
 @import "exercise/show";
+@import "exercise/index";

--- a/app/assets/stylesheets/pages/exercise/_index.scss
+++ b/app/assets/stylesheets/pages/exercise/_index.scss
@@ -1,0 +1,17 @@
+.w-70 {
+  min-width: 70%;
+}
+
+.progress-bar-container {
+  position: sticky;
+  top: 40px;
+  // background-color: rgb(200, 200, 200);
+  background-image: linear-gradient(226deg, rgba(31, 31, 31, 0.02) 0%, rgba(31, 31, 31, 0.02) 50%,rgba(164, 164, 164, 0.02) 50%, rgba(164, 164, 164, 0.02) 100%),linear-gradient(190deg, rgba(120, 120, 120, 0.01) 0%, rgba(120, 120, 120, 0.01) 50%,rgba(117, 117, 117, 0.01) 50%, rgba(117, 117, 117, 0.01) 100%),linear-gradient(34deg, rgba(159, 159, 159, 0.02) 0%, rgba(159, 159, 159, 0.02) 50%,rgba(205, 205, 205, 0.02) 50%, rgba(205, 205, 205, 0.02) 100%),linear-gradient(190deg, rgba(206, 206, 206, 0.01) 0%, rgba(206, 206, 206, 0.01) 50%,rgba(141, 141, 141, 0.01) 50%, rgba(141, 141, 141, 0.01) 100%),linear-gradient(341deg, rgba(233, 233, 233, 0.03) 0%, rgba(233, 233, 233, 0.03) 50%,rgba(125, 125, 125, 0.03) 50%, rgba(125, 125, 125, 0.03) 100%),linear-gradient(148deg, rgba(250, 250, 250, 0.03) 0%, rgba(250, 250, 250, 0.03) 50%,rgba(23, 23, 23, 0.03) 50%, rgba(23, 23, 23, 0.03) 100%),linear-gradient(147deg, rgba(253, 253, 253, 0.02) 0%, rgba(253, 253, 253, 0.02) 50%,rgba(171, 171, 171, 0.02) 50%, rgba(171, 171, 171, 0.02) 100%),linear-gradient(90deg, rgb(63,61,86),rgb(58,36,145));
+  padding: 16px;
+  border-radius: 8px;
+  color: white;
+}
+
+.progress-bar-bg {
+  background-image: linear-gradient(135deg, rgba(107, 107, 107,0.06) 0%, rgba(107, 107, 107,0.06) 50%,rgba(202, 202, 202,0.06) 50%, rgba(202, 202, 202,0.06) 100%),linear-gradient(90deg, rgb(20,20,20),rgb(20,20,20)); background-size: 30px 30px;
+}

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -2,6 +2,9 @@ class ExercisesController < ApplicationController
   before_action :set_exercise, only: %i[edit update show destroy]
   def index
     @exercises = policy_scope(Exercise)
+    @daily_stat = Music.daily_completion_stat(current_user)
+    @weekly_stat = Music.weekly_completion_stat(current_user)
+    @exercise_pie = Exercise.user_exercise_pie(current_user)
   end
 
   def new

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,6 +10,7 @@ import "channels";
 import "controllers";
 import "bootstrap";
 import "components";
+import "chartkick/chart.js"
 
 Rails.start();
 Turbolinks.start();

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -21,8 +21,14 @@ class Exercise < ApplicationRecord
 
     return string[-1] if difficulty > max_diff
 
-
     index = ((difficulty - min_diff) / (max_diff - min_diff) * (string.length - 1)).floor
     string[index]
+  end
+
+  def self.user_exercise_pie(user)
+    grouped = Exercise.includes(:musics).where(user: user).group_by do |ex|
+      ex.difficulty_string.capitalize
+    end
+    grouped.map { |k, v| { k => v.count } }.reduce(:merge)
   end
 end

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -20,6 +20,9 @@ class Music < ApplicationRecord
     scope: %i[exercise is_question]
   }
 
+  DAILY_TARGET = 10
+  WEEKLY_TARGET = 50
+
   enum status: {
     in_progress: 0,
     finished: 1
@@ -61,6 +64,18 @@ class Music < ApplicationRecord
 
   def valid_chords?
     valid_json?(chords)
+  end
+
+  def self.daily_completion_stat(user)
+    musics = Music.where(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day, user: user)
+    stat = (musics.count / DAILY_TARGET.to_f) * 100
+    stat > 100 ? 100 : stat
+  end
+
+  def self.weekly_completion_stat(user)
+    musics = Music.where(created_at: Time.zone.now.beginning_of_week..Time.zone.now.end_of_week, user: user)
+    stat = (musics.count / WEEKLY_TARGET.to_f) * 100
+    stat > 100 ? 100 : stat
   end
 
   private

--- a/app/views/exercises/_exercise_index_card.html.erb
+++ b/app/views/exercises/_exercise_index_card.html.erb
@@ -1,6 +1,6 @@
 <%= link_to exercise_path(ex), class: "remove-link-style" do %>
-    <div class="row justify-content-center">
-      <div class="teacher-exercise-card m-5 col-12 col-lg-8">
+    <div class="d-flex justify-content-center">
+      <div class="teacher-exercise-card my-5 flex-grow-1">
         <% if ex.musics.any? && ex.musics.first.finished?%>
           <i class="fas fa-circle fa-3x  d-flex align-items-center" data-toggle="tooltip" title="In progress" style="color:green"></i>
         <% end %>

--- a/app/views/exercises/_exercise_index_card.html.erb
+++ b/app/views/exercises/_exercise_index_card.html.erb
@@ -1,0 +1,47 @@
+<%= link_to exercise_path(ex), class: "remove-link-style" do %>
+    <div class="row justify-content-center">
+      <div class="teacher-exercise-card m-5 col-12 col-lg-8">
+        <% if ex.musics.any? && ex.musics.first.finished?%>
+          <i class="fas fa-circle fa-3x  d-flex align-items-center" data-toggle="tooltip" title="In progress" style="color:green"></i>
+        <% end %>
+
+        <% if ex.musics.any? && ex.musics.first.in_progress?%>
+          <i class="fas fa-circle fa-3x  d-flex align-items-center" data-toggle="tooltip" title="In progress" style="color:yellow"></i>
+
+        <% end %>
+
+
+        <div class="d-flex flex-column justify-content-center p-3 ms-4">
+        <div class="d-flex flex-column justify-content-end p-3 ms-4">
+        </div>
+        </div>
+        <div class="d-flex flex-grow-1 align-items-center justify-content-evenly me-5 ">
+         <p class="mb-0 lw-text-header prog-realign mr-5" data-toggle="tooltip" title="Chord progression"><%= ex.chord_progression %></p>
+          <p class="pl-4 ml-5 mb-0 lw-text-header fw-bold"> <%=ex.name %></p>
+        </div>
+        <div class="d-flex flex-column justify-content-evenly p-3 ml-4">
+      <%# <p class="mb-0 lw-text-header">Difficulty:</p> %>
+            <% if ex.difficulty_string == "easy"  %>
+              <p class="mb-0 lw-text-header text-center  text-primary" data-toggle="tooltip" title="Difficulty ">
+                Easy
+              </p>
+            <% end %>
+            <% if ex.difficulty_string == "intermediate" %>
+              <p class="mb-0 lw-text-header text-center  text-success" data-toggle="tooltip" title="Difficulty">
+                Inter
+              </p>
+            <% end %>
+            <% if ex.difficulty_string == "hard" %>
+              <p class="mb-0 lw-text-header text-center  text-danger" data-toggle="tooltip" title="Difficulty">
+                Hard
+              </p>
+            <% end %>
+            <% if ex.difficulty_string == "insane" %>
+              <p class="mb-0 lw-text-header text-center  text-danger" data-toggle="tooltip" title="Difficulty">
+                Insane
+              </p>
+            <% end %>
+        </div>
+      </div>
+    </div>
+<% end %>

--- a/app/views/exercises/_progress_bar.html.erb
+++ b/app/views/exercises/_progress_bar.html.erb
@@ -1,0 +1,18 @@
+<p class="my-2"><%= title %></p>
+<div>
+  <div class="progress w-100">
+    <div
+      class="progress-bar progress-bar-bg"
+      style="width: <%= stat %>%"
+      role="progressbar"
+      aria-valuenow="<%= stat %>"
+      aria-valuemin="0"
+      aria-valuemax="100">
+        <%= stat %> %
+      </div>
+  </div>
+  <div class="d-flex justify-content-between">
+    <p>0</p>
+    <p><%= max %></p>
+  </div>
+</div>

--- a/app/views/exercises/index.html.erb
+++ b/app/views/exercises/index.html.erb
@@ -1,6 +1,20 @@
 <h1 class="text-center mt-5">Exercises</h1>
-<ul>
-  <% @exercises.each do |ex| %>
-    <%= render "exercise_index_card", {ex: ex} %>
-  <% end %>
-</ul>
+
+<div class="d-flex px-5">
+  <div class="pe-5 w-70">
+    <% @exercises.each do |ex| %>
+      <%= render "exercise_index_card", {ex: ex} %>
+    <% end %>
+  </div>
+
+  <div class="d-flex flex-grow-1 justify-content-center text-center">
+    <div class="w-100">
+      <div class="progress-bar-container mt-5">
+      <%= render "progress_bar", {title: "Daily Progress", stat: @daily_stat, max: Music::DAILY_TARGET} %>
+      <%= render "progress_bar", {title: "Weekly Progress", stat: @weekly_stat, max: Music::WEEKLY_TARGET} %>
+      <p>Your challenges by difficulty!</p>
+      <%= pie_chart @exercise_pie, colors: ["#2e2d88", "#198854", "#b34d00", "#a21116"], legend: "bottom", library: { color: "#fff" }, dataset: {borderWidth: 1, paddingBotton: "10px"}%>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/exercises/index.html.erb
+++ b/app/views/exercises/index.html.erb
@@ -1,53 +1,6 @@
 <h1 class="text-center mt-5">Exercises</h1>
-
 <ul>
   <% @exercises.each do |ex| %>
-    <%= link_to exercise_path(ex), class: "remove-link-style" do %>
-    <div class="row justify-content-center">
-      <div class="teacher-exercise-card m-5 col-12 col-lg-8">
-        <% if ex.musics.any? && ex.musics.first.finished?%>
-          <i class="fas fa-circle fa-3x  d-flex align-items-center" data-toggle="tooltip" title="In progress" style="color:green"></i>
-        <% end %>
-
-        <% if ex.musics.any? && ex.musics.first.in_progress?%>
-          <i class="fas fa-circle fa-3x  d-flex align-items-center" data-toggle="tooltip" title="In progress" style="color:yellow"></i>
-
-        <% end %>
-
-
-        <div class="d-flex flex-column justify-content-center p-3 ms-4">
-        <div class="d-flex flex-column justify-content-end p-3 ms-4">
-        </div>
-        </div>
-        <div class="d-flex flex-grow-1 align-items-center justify-content-evenly me-5 ">
-         <p class="mb-0 lw-text-header prog-realign mr-5" data-toggle="tooltip" title="Chord progression"><%= ex.chord_progression %></p>
-          <p class="pl-4 ml-5 mb-0 lw-text-header fw-bold"> <%=ex.name %></p>
-        </div>
-        <div class="d-flex flex-column justify-content-evenly p-3 ml-4">
-      <%# <p class="mb-0 lw-text-header">Difficulty:</p> %>
-            <% if ex.difficulty_string == "easy"  %>
-              <p class="mb-0 lw-text-header text-center  text-primary" data-toggle="tooltip" title="Difficulty ">
-                Easy
-              </p>
-            <% end %>
-            <% if ex.difficulty_string == "intermediate" %>
-              <p class="mb-0 lw-text-header text-center  text-success" data-toggle="tooltip" title="Difficulty">
-                Inter
-              </p>
-            <% end %>
-            <% if ex.difficulty_string == "hard" %>
-              <p class="mb-0 lw-text-header text-center  text-danger" data-toggle="tooltip" title="Difficulty">
-                Hard
-              </p>
-            <% end %>
-            <% if ex.difficulty_string == "insane" %>
-              <p class="mb-0 lw-text-header text-center  text-danger" data-toggle="tooltip" title="Difficulty">
-                Insane
-              </p>
-            <% end %>
-        </div>
-      </div>
-    </div>
-    <% end %>
+    <%= render "exercise_index_card", {ex: ex} %>
   <% end %>
 </ul>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -74,7 +74,7 @@ ActiveRecord::Schema.define(version: 2022_03_06_024157) do
     t.bigint "exercise_id", null: false
     t.bigint "user_id", null: false
     t.text "content"
-    t.integer "vote", default: 0, null: false
+    t.integer "vote", default: 1, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["exercise_id"], name: "index_reviews_on_exercise_id"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.3",
     "bootstrap": "^5.1.3",
+    "chart.js": "^3.7.1",
+    "chartkick": "^4.1.1",
     "stimulus": "^3.0.1",
     "tone": "^14.7.77",
     "turbolinks": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1855,6 +1855,25 @@ chalk@^2.0, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chart.js@>=3.0.2, chart.js@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.7.1.tgz#0516f690c6a8680c6c707e31a4c1807a6f400ada"
+  integrity sha512-8knRegQLFnPQAheZV8MjxIXc5gQEfDFD897BJgv/klO/vtIyFFmgMXrNfgrXpbTr/XbTturxRgxIXx/Y+ASJBA==
+
+chartjs-adapter-date-fns@>=2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-2.0.0.tgz#5e53b2f660b993698f936f509c86dddf9ed44c6b"
+  integrity sha512-rmZINGLe+9IiiEB0kb57vH3UugAtYw33anRiw5kS2Tu87agpetDDoouquycWc9pRsKtQo5j+vLsYHyr8etAvFw==
+
+chartkick@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chartkick/-/chartkick-4.1.1.tgz#60d6e13a090c5334bd80ad8fb7da02aaf38fb936"
+  integrity sha512-+3+dIKZo8MzOiQFc4FZDZiRjDnrgVxgjk3tKXVclMcDF8yIJAEqSr5/l4pqpB2Rxye1s2Dg3j6bVA9eIeDbnCQ==
+  optionalDependencies:
+    chart.js ">=3.0.2"
+    chartjs-adapter-date-fns ">=2.0.0"
+    date-fns ">=2.0.0"
+
 "chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
@@ -2390,6 +2409,11 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
+
+date-fns@>=2.0.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"


### PR DESCRIPTION
I think we need to reconsider the architecture a bit as current the index page is fairly broken.

Currently, the page shows all the exercises. The user has no way to see what exercises they are currently working on or completed, meanwhile, as a user, that is what I would expect my first page to be. Not a random list of exercises. 

Also... all the details being displayed have no relation to the user.

[The cards progress](https://github.com/abauville/lickwars/blob/3c3dc3f1906eb1b4c37af8023aa8ea6a0f7f12b4/app/views/exercises/index.html.erb#L8) is just the first of the exercises music array. This could be anyone. How we change would impact what this would be. 

As an index page of exercises a user might want to do, there shouldn't be any progress if the user hasn't started it. So what actually is this page?

Having colors on the card for the difficulty and the progress isn't great ux in my opinion. It is confusing. 

The design I suggested in the past actually helps to clarify for the user so that it is clear what page they are on and the goal of the page. It also correlates with the teachers' feedback. A dashboard for the progress as a student, and a dashboard for progress as a teacher. We could have a separate index for the exercises to complete which makes it a clear distinction, otherwise, we can add a filter on the student dashboard where they can easily filter between challenges in progress, challenges finished, challenges not started. This would also allow them to filter by difficulty etc.

<img width="1440" alt="Screen Shot 2022-03-07 at 15 07 34" src="https://user-images.githubusercontent.com/87555651/156977549-71e34bd3-5d0a-4fe6-8b1e-0a28a18fe564.png">

This can be merged and we can create a new branch to solve the issues above. 