### PR TITLE
status circle

### DIFF
--- a/app/views/exercises/index.html.erb
+++ b/app/views/exercises/index.html.erb
@@ -1,18 +1,14 @@
 <h1 class="text-center mt-5">Exercises</h1>
-
+<% colors = ["color:gray", "color:yellow", "color:green"] %>
 <ul>
   <% @exercises.each do |ex| %>
     <%= link_to exercise_path(ex), class: "remove-link-style" do %>
     <div class="row justify-content-center">
       <div class="teacher-exercise-card m-5 col-12 col-lg-8">
-        <% if ex.musics.any? && ex.musics.first.finished?%>
-          <i class="fas fa-circle fa-3x  d-flex align-items-center" data-toggle="tooltip" title="In progress" style="color:green"></i>
-        <% end %>
+        <% status = ex.attempt_music(current_user) ? Music.statuses[ex.attempt_music(current_user).status] : 2 %>
 
-        <% if ex.musics.any? && ex.musics.first.in_progress?%>
-          <i class="fas fa-circle fa-3x  d-flex align-items-center" data-toggle="tooltip" title="In progress" style="color:yellow"></i>
+        <i class="fas fa-circle fa-3x  d-flex align-items-center" data-toggle="tooltip" title="In progress" style=<%= colors[status] %>></i>
 
-        <% end %>
 
 
         <div class="d-flex flex-column justify-content-center p-3 ms-4">


### PR DESCRIPTION
Adresses issue #51 
I fixed the logic to display the status of the exercise (not done, in progress, finished) on the card.
@markiecyt , don't hesitate to ditch that colored circle of the design. But at least that gives you the logic for filtering out the finished exercises
<img width="1095" alt="Screen Shot 2022-03-07 at 19 28 25" src="https://user-images.githubusercontent.com/39847270/157013978-1984e7c9-511c-4d8f-a707-72563c6593de.png">
.