### PR TITLE
Results page modify

### DIFF
--- a/app/assets/stylesheets/components/_modal.scss
+++ b/app/assets/stylesheets/components/_modal.scss
@@ -1,4 +1,4 @@
-.lw-modal-body {
+.modal-body {
   max-width: 700px !important;
   height: 90%;
 }

--- a/app/views/exercises/_results_card.html.erb
+++ b/app/views/exercises/_results_card.html.erb
@@ -14,19 +14,20 @@
               </svg>
             </button>
           </h1>
-          <%= simple_form_for([@exercise,@review]) do |form| %>
-            Share your thoughts:
-            <%= form.input :content, label: false, class: "form-control", placeholder: @review.content %>
-            <div class="d-flex justify-content-center">
+          <%# <%= simple_form_for([@exercise,@review]) do |form| %>
+            <%# Share your thoughts: %>
+            <%#= form.input :content, label: false, class: "form-control", placeholder: @review.content %>
+            <%# <div class="d-flex justify-content-center">
               <%= form.submit 'Submit', class: "lw-button lw-btn-lg" %>
-            </div>
-          <% end %>
-          <h6 class="mt-4">Previous comments on this exercise:</h6>
+            <%# </div> %>
+          <%# end %>
+          <%# <h6 class="mt-4">Previous comments on this exercise:</h6>
           <div class="h-50 pb-3 overflow-scroll">
             <% @exercise.reviews.order(created_at: :asc).each do |review| %>
-              <%= render 'shared/review_card', {review: review} %>
-            <% end %>
-          </div>
+              <%#= render 'shared/review_card', {review: review} %>
+            <%# end %>
+          <%# </div> %>
+      </div>
         </div>
       </div>
     </div>

--- a/app/views/exercises/_results_card.html.erb
+++ b/app/views/exercises/_results_card.html.erb
@@ -27,9 +27,8 @@
               <%#= render 'shared/review_card', {review: review} %>
             <%# end %>
           <%# </div> %>
-          <div class="progress-bar-container mt-5">
-            <%= render "progress_bar", {title: "Daily Progress", stat: @daily_stat, max: Music::DAILY_TARGET} %>
-            <%= render "progress_bar", {title: "Weekly Progress", stat: @weekly_stat, max: Music::WEEKLY_TARGET} %>
+          <div class="text-center mt-5">
+            <%= link_to "Find next exercise", exercises_path, class: "exercise-button" %>
           </div>
         </div>
       </div>

--- a/app/views/exercises/_results_card.html.erb
+++ b/app/views/exercises/_results_card.html.erb
@@ -1,8 +1,8 @@
 <div class="modal fade" id="commentModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-  <div class="modal-dialog lw-modal-body z-10 modal-dialog-centered">
-    <div class="modal-content h-100">
+  <div class="modal-dialog modal-body z-10 modal-dialog-centered">
+    <div class="modal-content">
       <div class="modal-body h-100 p-0">
-        <div class="card-result h-100 p-5 pb-0">
+        <div class="card-result h-100 p-5">
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
           </button>
           <h1 class="text-center">Congratulations!</h1>
@@ -27,7 +27,10 @@
               <%#= render 'shared/review_card', {review: review} %>
             <%# end %>
           <%# </div> %>
-      </div>
+          <div class="progress-bar-container mt-5">
+            <%= render "progress_bar", {title: "Daily Progress", stat: @daily_stat, max: Music::DAILY_TARGET} %>
+            <%= render "progress_bar", {title: "Weekly Progress", stat: @weekly_stat, max: Music::WEEKLY_TARGET} %>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<img width="1100" alt="スクリーンショット 2022-03-08 13 09 42" src="https://user-images.githubusercontent.com/96113893/157164732-005232c4-0607-4da0-9ee6-f4de7d77cb5b.png">

- remove comments
- add 'Find next exercise' button ( when user click on this, back to /exercises page )
- size modify

Users already can see the progress bar in exercises page,
so I didn't put the progress bar in results page.


