### PR TITLE
Score continue value input

### DIFF
--- a/app/javascript/controllers/score_controller.js
+++ b/app/javascript/controllers/score_controller.js
@@ -168,10 +168,10 @@ export default class extends Controller {
     // divide last note if necessary
     if (duration > target_duration + tol) {
       this.divideNote(index+i, Math.round(1.0/remainder), false)
-      this.music.notes.splice(index+i,1)
+      // this.music.notes.splice(index+i,1)
     }
     // remove notes to be merged
-    for (let j = 1; j<i; j++) {
+    for (let j = 1; j<=i; j++) {
       this.music.notes.splice(index+j,1)
     }
     this.music.notes[index][1] = newValue

--- a/app/javascript/controllers/score_controller.js
+++ b/app/javascript/controllers/score_controller.js
@@ -76,7 +76,11 @@ export default class extends Controller {
     const refMidiNums = {
       KeyC: 12, KeyD: 14, KeyE: 16, KeyF: 17, KeyG: 19, KeyA: 21, KeyB: 23
     };
+    const noteValues = {
+      Digit3: 16, Digit4: 8, Digit5: 4, Digit6: 2, Digit7: 1
+    }
     switch (event.code) {
+
       case "ArrowUp": // move note up
         this.updateNote(
           index, "#", event.metaKey || event.ctrlKey ? midiNum + 12 : midiNum + 1
@@ -109,61 +113,66 @@ export default class extends Controller {
         svgNote = this.updateScore(event, index)
         this.selectNextNote(event, index, svgNote, false)
         break;
+      case "Digit3": // 16th note, follows MuseScore's key map
       case "Digit4": // 8th note
-        this.divideNote(index, 8)
-        this.updateScore(event, index)
-        break;
-      case "Digit5": // 4th note
-        const new_value = 4
-        const old_value = this.music.notes[index][1]
-        if (new_value > old_value) {
-          console.log("DIVIDE")
-          this.divideNote(index, 4)
+      case "Digit5": // quarter note
+      case "Digit6": // half note
+      case "Digit7": // whole note
+        const newValue = noteValues[event.code]
+        const oldValue = this.music.notes[index][1]
+        if (newValue > oldValue) {
+          this.divideNote(index, newValue)
         } else {
-          console.log("MEEEERGE")
-          // check first if I have enough place to add that note in that measure
-          let duration = 0.0
-          const target_duration = 1.0/new_value
-          let i = 0
-          const tol = 1e-6
-          let remainder
-          console.log("notes", this.music.notes.slice(index))
-          while (duration < target_duration - tol) {
-            duration += 1.0/this.music.notes[index+i][1]
-            if (duration < target_duration - tol) {
-              remainder = target_duration - duration
-            }
-            i += 1
-          }
-          if (duration > target_duration + tol) {
-            // divide into remainder
-            this.divideNote(index+i-1, Math.round(1.0/remainder), false)
-            this.music.notes.splice(index+i-1,1)
-          }
-          for (let j = 1; j<i-1; j++) {
-            this.music.notes.splice(index+j,1)
-          }
-
-          this.music.notes[index][1] = new_value
-          console.log("notes", this.music.notes.slice(index))
+          this.mergeNotes(index, newValue)
         }
         this.updateScore(event, index)
         break;
     }
   }
 
-  divideNote(index, new_value, fillWithRests = true) {
+  divideNote(index, newValue, fillWithRests = true) {
     const note = this.music.notes[index][0]
-    const prev_value = this.music.notes[index][1]
-    for (let i = 0; i < Math.log2(new_value) - Math.log2(prev_value); i++) {
+    const prevValue = this.music.notes[index][1]
+    for (let i = 0; i < Math.log2(newValue) - Math.log2(prevValue); i++) {
       if (fillWithRests) {
-        this.music.notes.splice(index+1+i, 0, [["r", "A4"], new_value/(Math.pow(2,i))]);
+        this.music.notes.splice(index+1+i, 0, [["r", "A4"], newValue/(Math.pow(2,i))]);
       } else {
-        this.music.notes.splice(index+1+i, 0, [note, new_value/(Math.pow(2,i))]);
+        this.music.notes.splice(index+1+i, 0, [note, newValue/(Math.pow(2,i))]);
       }
 
     }
-    this.music.notes[index][1] = new_value
+    this.music.notes[index][1] = newValue
+  }
+
+  mergeNotes(index, newValue) {
+    // Merging strategy
+    // check if the next notes can be merged directly or if the last note
+    // would need to be divided before merging
+    // e.g. 8th + 8th notes can be merged into a quarter note
+    // but, 8th + 2nd, will be merged into quarter + (8th + quarter) (in that case remainder == 8th)
+    // Warning: this function is not yet aware of barlines, and will cause an error when dividing notes across a barline
+
+    let duration = 1.0/this.music.notes[index][1]
+    const target_duration = 1.0/newValue
+    let i = 0
+    const tol = 1e-6
+    let remainder = 0
+    // compute remainder
+    while (duration < target_duration - tol) {
+      i += 1
+      remainder = target_duration - duration
+      duration += 1.0/this.music.notes[index+i][1]
+    }
+    // divide last note if necessary
+    if (duration > target_duration + tol) {
+      this.divideNote(index+i, Math.round(1.0/remainder), false)
+      this.music.notes.splice(index+i,1)
+    }
+    // remove notes to be merged
+    for (let j = 1; j<i; j++) {
+      this.music.notes.splice(index+j,1)
+    }
+    this.music.notes[index][1] = newValue
   }
 
   selectPreviousNote(event, index, svgNote, playNote = true) {

--- a/app/javascript/controllers/score_controller.js
+++ b/app/javascript/controllers/score_controller.js
@@ -168,7 +168,6 @@ export default class extends Controller {
     // divide last note if necessary
     if (duration > target_duration + tol) {
       this.divideNote(index+i, Math.round(1.0/remainder), false)
-      // this.music.notes.splice(index+i,1)
     }
     // remove notes to be merged
     for (let j = 1; j<=i; j++) {

--- a/app/javascript/controllers/score_controller.js
+++ b/app/javascript/controllers/score_controller.js
@@ -152,11 +152,13 @@ export default class extends Controller {
     // but, 8th + 2nd, will be merged into quarter + (8th + quarter) (in that case remainder == 8th)
     // Warning: this function is not yet aware of barlines, and will cause an error when dividing notes across a barline
 
+    // check first if I have enough place to add that note in that measure
     let duration = 1.0/this.music.notes[index][1]
     const target_duration = 1.0/newValue
     let i = 0
     const tol = 1e-6
-    let remainder = 0
+    let remainder
+    console.log("notes", this.music.notes.slice(index))
     // compute remainder
     while (duration < target_duration - tol) {
       i += 1


### PR DESCRIPTION
Now value input works (within a measure). Changing the note value breaks up a note or merges the next note within it (e.g. two 8th note are merged into one quarter). If the next note is not a exact division it breaks note accordingly (e.g. 8th + half are broken into 4th + 8th + half). However, ties or dotted notes are not implemented yet. Also trying to merge notes across a measure will cause an error. Example:
original:
<img width="899" alt="Screen Shot 2022-03-09 at 13 08 46" src="https://user-images.githubusercontent.com/39847270/157371128-917110fd-08be-4e36-bd5e-7248be08c423.png">
Several alterations, dividing or merging notes
<img width="885" alt="Screen Shot 2022-03-09 at 13 09 04" src="https://user-images.githubusercontent.com/39847270/157371135-b5a1f110-2cbd-4750-bbdb-adbdf621a6b3.png">

