### PR TITLE
disable buttons while the piano samples are loading

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -66,13 +66,6 @@
   width: 160px;
 }
 
-.play-button {
-  // color: $primary;
-  // &:hover {
-  //   color: #7c9b9a;
-  //   cursor: pointer;
-  // }
-}
 
 .exercise-button {
   opacity: 1 !important;
@@ -145,10 +138,23 @@ $hover-purple: #252536;
   justify-content: center;
   align-items: center;
   font-size: $font-size-base*1.5;
-  cursor: pointer;
+  border: none;
+  // cursor: pointer;
   &:hover {
     background-color: $hover-purple;
     // color: $purple;
+  }
+  &:disabled {
+    background-color: #a6a6ac;
+    color: #cdcdd1;
+  }
+}
+
+#play-question {
+  &:disabled {
+    cursor: default;
+    background-color: #a6a6ac;
+    color: #cdcdd1;
   }
 }
 

--- a/app/javascript/controllers/score_controller.js
+++ b/app/javascript/controllers/score_controller.js
@@ -21,7 +21,7 @@ export default class extends Controller {
   connect() {
     this.bpm = this.bpmValue;
     this.music = new Music(this.notesValue, "[]", this.bpm);
-    this.boomBox = new BoomBox();
+    this.boomBox = new BoomBox(document.querySelector("#play-attempt"));
     this.score = new Score(this.music);
     this.initConverters();
     this.currentSelection = null;

--- a/app/javascript/controllers/tone_controller.js
+++ b/app/javascript/controllers/tone_controller.js
@@ -10,7 +10,7 @@ export default class extends Controller {
   };
 
   connect() {
-    this.boomBox = new BoomBox();
+    this.boomBox = new BoomBox(document.querySelector("#play-question"));
     this.music = new Music(
       this.notesValue,
       this.chordsValue,

--- a/app/javascript/models/boom_box.js
+++ b/app/javascript/models/boom_box.js
@@ -2,14 +2,15 @@ import * as Tone from "tone";
 import { Piano } from "@tonejs/piano";
 
 export class BoomBox {
-  constructor() {
+  constructor(target) {
     const vol = new Tone.Volume(-12).toDestination();
     this.piano = new Piano({
       release: true,
       velocities: 5 });
     this.piano.connect(vol);
     this.piano.load().then(() => {
-      console.log("loaded!");
+      console.log("loaded! target:", target);
+      target.disabled = false
     });
     this.breakLoop = false;
   }

--- a/app/views/exercises/_score.html.erb
+++ b/app/views/exercises/_score.html.erb
@@ -27,15 +27,16 @@
       <div class="keyboard-shortcut">7</div>
     </button>
   <div class="d-flex justify-content-center align-items-center">
-    <div
+    <button
       id="play-attempt"
       class='play-button'
       title='play my input'
       data-action='click->score#playAttempt'
       data-play-html="<i class='far fa-play-circle'></i>"
-      data-stop-html="<i class='far fa-stop-circle'></i>">
+      data-stop-html="<i class='far fa-stop-circle'></i>"
+      disabled>
         <i class='far fa-play-circle'></i>
-    </div>
+    </button>
 
     <div id="score" data-score-target="score"></div>
     <p data-score-target="output"></p>

--- a/app/views/exercises/_tone.html.erb
+++ b/app/views/exercises/_tone.html.erb
@@ -5,14 +5,16 @@
       data-tone-chords-value="<%= @question_music.chords %>"
       data-tone-bpm-value="<%= @question_music.bpm %>">
   <%# <p class="lw-button lw-btn-sm text-center mx-2 shine"  data-bs-toggle="modal" data-bs-target="#helpModal">Help</p> %>
-  <div id='play-question'>
-    <p
+  <div>
+    <button id='play-question'
       class='lw-button w-btn-sm  text-center mb-0 mx-2'
       data-play-html="<i class='far fa-play-circle'></i> Question"
       data-stop-html="<i class='far fa-stop-circle'></i> Question"
-      data-action='click->tone#play'>
+      data-action='click->tone#play'
+      disabled
+      >
       <i class='far fa-play-circle'></i> Question
-    </p>
+    </button>
   </div>
   <%# <p class="lw-button lw-btn-sm text-center mb-0 mx-2 my-0">Check</p> %>
   <%= simple_form_for(@attempt_music, @action) do |f| %>


### PR DESCRIPTION
Question and attempt play buttons are disabled while the piano samples are loading. Replaces the loading page (pull request #137 )

<img width="778" alt="Screen Shot 2022-03-11 at 10 35 25" src="https://user-images.githubusercontent.com/39847270/157784969-94a04bcc-3d92-4b60-9721-de07545b6120.png">
