### PR TITLE
More visual feedback on play

### DIFF
--- a/app/assets/stylesheets/components/_score.scss
+++ b/app/assets/stylesheets/components/_score.scss
@@ -1,5 +1,5 @@
 $select: rgb(236, 38, 38);
-$hover: #3125e0;
+$hover: #4337ee;
 div#score {
   // background-color: $body-color;
   overflow: scroll;

--- a/app/assets/stylesheets/components/_score.scss
+++ b/app/assets/stylesheets/components/_score.scss
@@ -23,7 +23,12 @@ div#score {
   stroke: rgb(46, 126, 216);
   fill: rgb(46, 126, 216);
   filter: drop-shadow(0 0 0.1rem rgb(46, 126, 216));
+}
 
+path.stave-highlight {
+  stroke: rgb(46, 126, 216);
+  stroke-width: 2;
+  filter: drop-shadow(0 0 0.2rem rgb(46, 126, 216));
 }
 
 ::-webkit-scrollbar {

--- a/app/assets/stylesheets/components/_score.scss
+++ b/app/assets/stylesheets/components/_score.scss
@@ -1,21 +1,23 @@
+$select: rgb(236, 38, 38);
+$hover: #3125e0;
 div#score {
   // background-color: $body-color;
   overflow: scroll;
 }
 .vf-stavenote:hover path {
-  stroke: rgb(36, 80, 255);
-  fill: rgb(36, 80, 255);
-  filter: drop-shadow(0 0 0.1rem rgba(36, 80, 255, 0.8));
+  stroke: $hover;
+  fill: $hover;
+  filter: drop-shadow(0 0 0.1rem $hover);
 }
 
 .vf-stavenote.selected path {
-  stroke: red;
-  fill: red;
+  stroke: $select;
+  fill: $select;
 }
 
 .vf-stavenote:focus {
-  stroke: red;
-  fill: red;
+  stroke: $select;
+  fill: $select;
   outline: none;
 }
 

--- a/app/javascript/models/boom_box.js
+++ b/app/javascript/models/boom_box.js
@@ -45,7 +45,7 @@ export class BoomBox {
   }
 
 
-  initAnimationAttempt(event, music) {
+  initAttemptAnimation(event, music) {
     // const wholeNoteLength = (4.0 * 60.0) / this.bpm;
 
     let playbackArrays = music.playbackArrays('notes');
@@ -65,6 +65,46 @@ export class BoomBox {
       // console.log("offEvent", index);
       notes[index].classList.toggle("highlight")
     }), offSequence).start(0)
+
+  }
+
+  initQuestionAnimation(event, music) {
+    console.log("initQuestionAnimation")
+    const wholeNoteLength = (4.0 * 60.0) / music.bpm;
+    // for (let i=0; i<4) {
+
+    // }
+
+    const svg = document.querySelector("svg");
+    const staveLines = svg.querySelectorAll("[stroke='#999999']");
+    // const staveLines = []
+    // paths.forEach((path) => {
+    //   if (path.style.stroke === '#999999') {
+    //     staveLines.push(path)
+    //   }
+    // });
+    // console.log("paths", paths)
+    console.log("stavelines", staveLines)
+    const sequence = []
+    const offSequence = []
+    staveLines.forEach((stave, index) => {
+      const i_measure = Math.floor(index / 5)
+      sequence.push([wholeNoteLength * i_measure, stave])
+      offSequence.push([wholeNoteLength * (i_measure + 1), stave])
+    })
+    console.log("seq", sequence)
+    console.log("offSequence", offSequence)
+
+    const onEvents = new Tone.Part(((time, stave) => {
+      console.log("onEvent", time, stave);
+      stave.classList.toggle("stave-highlight")
+    }), sequence).start(0)
+
+    const offEvents = new Tone.Part(((time, stave) => {
+      // console.log("offEvent", index);
+      stave.classList.toggle("stave-highlight")
+    }), offSequence).start(0)
+
 
   }
 
@@ -90,10 +130,14 @@ export class BoomBox {
     const endTime = this.initSequences(event, music)
     const stopTransport = new Tone.Part(((time, t) => {
       this.togglePlayStop(t)
-    }), [[endTime+.01, event.currentTarget]]).start(0)
+    }), [[endTime+0.8, event.currentTarget]]).start(0)
 
     if (event.currentTarget.id === "play-attempt") {
-      this.initAnimationAttempt(event, music)
+      this.initAttemptAnimation(event, music)
+    }
+    console.log("target", event.currentTarget)
+    if (event.currentTarget.id === "play-question") {
+      this.initQuestionAnimation(event, music)
     }
 
     Tone.start();

--- a/app/javascript/models/boom_box.js
+++ b/app/javascript/models/boom_box.js
@@ -71,22 +71,13 @@ export class BoomBox {
   initQuestionAnimation(event, music) {
     console.log("initQuestionAnimation")
     const wholeNoteLength = (4.0 * 60.0) / music.bpm;
-    // for (let i=0; i<4) {
 
-    // }
-
+    // highlight staves
     const svg = document.querySelector("svg");
     const staveLines = svg.querySelectorAll("[stroke='#999999']");
-    // const staveLines = []
-    // paths.forEach((path) => {
-    //   if (path.style.stroke === '#999999') {
-    //     staveLines.push(path)
-    //   }
-    // });
-    // console.log("paths", paths)
     console.log("stavelines", staveLines)
-    const sequence = []
-    const offSequence = []
+    let sequence = []
+    let offSequence = []
     staveLines.forEach((stave, index) => {
       const i_measure = Math.floor(index / 5)
       sequence.push([wholeNoteLength * i_measure, stave])
@@ -105,6 +96,23 @@ export class BoomBox {
       stave.classList.toggle("stave-highlight")
     }), offSequence).start(0)
 
+    // highlight notes
+    let playbackArrays = music.playbackArrays('notes');
+    sequence = playbackArrays[0];
+    const lengths = playbackArrays[1];
+    sequence = sequence.map((s, i) => {return [Math.floor(s[0]/wholeNoteLength) * wholeNoteLength, i]})
+    offSequence = sequence.map((s, i) => {return [(Math.floor(s[0]/wholeNoteLength) + 1) * wholeNoteLength, s[1]]})
+    offSequence = offSequence.map((s, i) => {return [s[0], i]})
+    const notes = svg.querySelectorAll(".vf-stavenote");
+    const noteOnEvents = new Tone.Part(((time, index) => {
+      // console.log("onEvent", index);
+      notes[index].classList.toggle("highlight")
+    }), sequence).start(0)
+
+    const noteOffEvents = new Tone.Part(((time, index) => {
+      // console.log("offEvent", index);
+      notes[index].classList.toggle("highlight")
+    }), offSequence).start(0)
 
   }
 

--- a/app/views/exercises/_tone.html.erb
+++ b/app/views/exercises/_tone.html.erb
@@ -5,8 +5,9 @@
       data-tone-chords-value="<%= @question_music.chords %>"
       data-tone-bpm-value="<%= @question_music.bpm %>">
   <%# <p class="lw-button lw-btn-sm text-center mx-2 shine"  data-bs-toggle="modal" data-bs-target="#helpModal">Help</p> %>
-  <div id='play-question'>
+  <div >
     <p
+      id='play-question'
       class='lw-button w-btn-sm  text-center mb-0 mx-2'
       data-play-html="<i class='far fa-play-circle'></i> Question"
       data-stop-html="<i class='far fa-stop-circle'></i> Question"


### PR DESCRIPTION
Highlights the content of the relevant measure during question playback

<img width="963" alt="Screen Shot 2022-03-11 at 12 19 51" src="https://user-images.githubusercontent.com/39847270/157795903-baa35284-770e-4ce9-b3a6-87caa76588b3.png">

The key signature and clef are not highlighted yet, but I'll fix that later