### PR TITLE
Add object-fit: cover; to avatar

### DIFF
--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -3,6 +3,7 @@
   height: 42px;
   border-radius: 50%;
   cursor: pointer;
+  object-fit: cover;
 }
 .avatar-large {
   width: 56px;


### PR DESCRIPTION
I remember Yann’s advice we got yesterday.

<img width="130" alt="スクリーンショット 2022-03-11 12 57 07" src="https://user-images.githubusercontent.com/96113893/157801302-7c709c76-53b3-423e-bdee-27918549410d.png">
<img width="96" alt="スクリーンショット 2022-03-11 13 17 08" src="https://user-images.githubusercontent.com/96113893/157801312-1d27d401-132f-4b14-a25f-c7e1011db2c1.png">


↓


<img width="117" alt="スクリーンショット 2022-03-11 13 16 36" src="https://user-images.githubusercontent.com/96113893/157801327-437ff59c-74bf-4c15-902e-d8f051813461.png">
<img width="83" alt="スクリーンショット 2022-03-11 13 17 26" src="https://user-images.githubusercontent.com/96113893/157801333-b13cdc0f-1cbd-4788-b6d0-3df32c317406.png">


