### PR TITLE
Fix question anim highlight

### DIFF
--- a/app/assets/stylesheets/components/_score.scss
+++ b/app/assets/stylesheets/components/_score.scss
@@ -21,15 +21,16 @@ div#score {
   outline: none;
 }
 
-.vf-stavenote.highlight path{
+// .vf-stavenote.highlight path{
+//   stroke: rgb(46, 126, 216);
+//   fill: rgb(46, 126, 216);
+//   filter: drop-shadow(0 0 0.1rem rgb(46, 126, 216));
+// }
+
+path.highlight {
   stroke: rgb(46, 126, 216);
   fill: rgb(46, 126, 216);
-  filter: drop-shadow(0 0 0.1rem rgb(46, 126, 216));
-}
-
-path.stave-highlight {
-  stroke: rgb(46, 126, 216);
-  stroke-width: 2;
+  // stroke-width: 2;
   filter: drop-shadow(0 0 0.2rem rgb(46, 126, 216));
 }
 

--- a/app/javascript/models/boom_box.js
+++ b/app/javascript/models/boom_box.js
@@ -1,5 +1,6 @@
 import * as Tone from "tone";
 import { Piano } from "@tonejs/piano";
+import { X } from "vexflow/src/registry";
 
 export class BoomBox {
   constructor(target) {
@@ -79,51 +80,49 @@ export class BoomBox {
     console.log("stavelines", staveLines)
     let sequence = []
     let offSequence = []
-    let yTopStave = Number(staveLines[0].attributes.d.value.split('L')[0].split(' ')[1])
+    let yTopStave = Number(staveLines[0].attributes.d.value.split(/[LM]/)[1].split(' ')[1])
 
     let y
-    let i_measure = -1
+    let i_measure
+    let xStartMeasures = []
+    let xEndMeasures = []
     staveLines.forEach((stave, index) => {
-      y = Number(stave.attributes.d.value.split('L')[0].split(' ')[1])
+      y = Number(stave.attributes.d.value.split(/[LM]/)[1].split(' ')[1])
       if (y === yTopStave) {
-        i_measure += 1
+        xStartMeasures.push(Number(stave.attributes.d.value.split(/[LM]/)[1].split(' ')[0]))
+        xEndMeasures.push(Number(stave.attributes.d.value.split(/[LM]/)[2].split(' ')[0]))
       }
-
-      // const i_measure = Math.floor(index / 5)
-      sequence.push([wholeNoteLength * i_measure, stave])
-      offSequence.push([wholeNoteLength * (i_measure + 1), stave])
     })
+    console.log("xStartMeasures", xStartMeasures)
     console.log("seq", sequence)
     console.log("offSequence", offSequence)
 
+    const n_measures = xStartMeasures.length
+    const paths = svg.querySelectorAll("path");
+    let i_m, xStart, xEnd
+    paths.forEach((path, index) => {
+      for (i_m = 0; i_m < n_measures; i_m++) {
+        xStart = Number(path.attributes.d.value.split(/[LM]/)[1].split(' ')[0])
+        xEnd = Number(path.attributes.d.value.split(/[LM]/)[1].split(' ')[0])
+        if (xStart >= xStartMeasures[i_m] && xEnd < xEndMeasures[i_m]) {
+          i_measure = i_m
+          break;
+        }
+      }
+      sequence.push([wholeNoteLength * i_measure, path])
+      offSequence.push([wholeNoteLength * (i_measure+1), path])
+    })
+
     const onEvents = new Tone.Part(((time, stave) => {
       console.log("onEvent", time, stave);
-      stave.classList.toggle("stave-highlight")
+      stave.classList.toggle("highlight")
     }), sequence).start(0)
 
     const offEvents = new Tone.Part(((time, stave) => {
       // console.log("offEvent", index);
       stave.classList.toggle("stave-highlight")
+      stave.classList.toggle("highlight")
     }), offSequence).start(0)
-
-    // // highlight notes
-    // let playbackArrays = music.playbackArrays('notes');
-    // sequence = playbackArrays[0];
-    // const lengths = playbackArrays[1];
-    // sequence = sequence.map((s, i) => {return [Math.floor(s[0]/wholeNoteLength) * wholeNoteLength, i]})
-    // offSequence = sequence.map((s, i) => {return [(Math.floor(s[0]/wholeNoteLength) + 1) * wholeNoteLength, s[1]]})
-    // offSequence = offSequence.map((s, i) => {return [s[0], i]})
-    // const notes = svg.querySelectorAll(".vf-stavenote");
-    // const noteOnEvents = new Tone.Part(((time, index) => {
-    //   // console.log("onEvent", index);
-    //   notes[index].classList.toggle("highlight")
-    // }), sequence).start(0)
-
-    // const noteOffEvents = new Tone.Part(((time, index) => {
-    //   // console.log("offEvent", index);
-    //   notes[index].classList.toggle("highlight")
-    // }), offSequence).start(0)
-
   }
 
   togglePlayStop(target) {

--- a/app/javascript/models/boom_box.js
+++ b/app/javascript/models/boom_box.js
@@ -79,8 +79,17 @@ export class BoomBox {
     console.log("stavelines", staveLines)
     let sequence = []
     let offSequence = []
+    let yTopStave = Number(staveLines[0].attributes.d.value.split('L')[0].split(' ')[1])
+
+    let y
+    let i_measure = -1
     staveLines.forEach((stave, index) => {
-      const i_measure = Math.floor(index / 5)
+      y = Number(stave.attributes.d.value.split('L')[0].split(' ')[1])
+      if (y === yTopStave) {
+        i_measure += 1
+      }
+
+      // const i_measure = Math.floor(index / 5)
       sequence.push([wholeNoteLength * i_measure, stave])
       offSequence.push([wholeNoteLength * (i_measure + 1), stave])
     })
@@ -97,23 +106,23 @@ export class BoomBox {
       stave.classList.toggle("stave-highlight")
     }), offSequence).start(0)
 
-    // highlight notes
-    let playbackArrays = music.playbackArrays('notes');
-    sequence = playbackArrays[0];
-    const lengths = playbackArrays[1];
-    sequence = sequence.map((s, i) => {return [Math.floor(s[0]/wholeNoteLength) * wholeNoteLength, i]})
-    offSequence = sequence.map((s, i) => {return [(Math.floor(s[0]/wholeNoteLength) + 1) * wholeNoteLength, s[1]]})
-    offSequence = offSequence.map((s, i) => {return [s[0], i]})
-    const notes = svg.querySelectorAll(".vf-stavenote");
-    const noteOnEvents = new Tone.Part(((time, index) => {
-      // console.log("onEvent", index);
-      notes[index].classList.toggle("highlight")
-    }), sequence).start(0)
+    // // highlight notes
+    // let playbackArrays = music.playbackArrays('notes');
+    // sequence = playbackArrays[0];
+    // const lengths = playbackArrays[1];
+    // sequence = sequence.map((s, i) => {return [Math.floor(s[0]/wholeNoteLength) * wholeNoteLength, i]})
+    // offSequence = sequence.map((s, i) => {return [(Math.floor(s[0]/wholeNoteLength) + 1) * wholeNoteLength, s[1]]})
+    // offSequence = offSequence.map((s, i) => {return [s[0], i]})
+    // const notes = svg.querySelectorAll(".vf-stavenote");
+    // const noteOnEvents = new Tone.Part(((time, index) => {
+    //   // console.log("onEvent", index);
+    //   notes[index].classList.toggle("highlight")
+    // }), sequence).start(0)
 
-    const noteOffEvents = new Tone.Part(((time, index) => {
-      // console.log("offEvent", index);
-      notes[index].classList.toggle("highlight")
-    }), offSequence).start(0)
+    // const noteOffEvents = new Tone.Part(((time, index) => {
+    //   // console.log("offEvent", index);
+    //   notes[index].classList.toggle("highlight")
+    // }), offSequence).start(0)
 
   }
 

--- a/app/javascript/models/boom_box.js
+++ b/app/javascript/models/boom_box.js
@@ -131,6 +131,8 @@ export class BoomBox {
       const svg = document.querySelector("svg");
       const notes = svg.querySelectorAll(".vf-stavenote");
       notes.forEach((n) => {n.classList.remove("highlight")})
+      const staveLines = svg.querySelectorAll("[stroke='#999999']");
+      staveLines.forEach((s) => {s.classList.remove("stave-highlight")})
     }
   }
 


### PR DESCRIPTION
The question highlighting had a number of problems:
- The note highlight was based on the number of notes in the question, instead of the attempt
- stave highlight was being messed up by small segments on note above or below the staff (e.g. middle C)
- The key signature, clef and some note stems were not highlighted

I refactored the function and now the highlighting is based on position, which is simpler and more robust
<img width="1058" alt="Screen Shot 2022-03-11 at 16 20 33" src="https://user-images.githubusercontent.com/39847270/157821337-5e96bbb5-ef42-4469-a5f2-8f518b626814.png">
.